### PR TITLE
Fix MediaWiki API error handling and User-Agent requirement

### DIFF
--- a/app/Services/MediawikiService.php
+++ b/app/Services/MediawikiService.php
@@ -45,8 +45,21 @@ class MediawikiService {
             throw new \Exception('Failed to fetch data from the API: ' . curl_error($ch));
         }
 
-        if (curl_getinfo($ch, CURLINFO_HTTP_CODE) === 0) {
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        
+        if ($httpCode === 0) {
+            curl_close($ch);
             throw new \Exception('Request to the API timed out.');
+        }
+
+        if ($httpCode !== 200) {
+            curl_close($ch);
+            \Log::error('MediaWiki API request failed', [
+                'http_code' => $httpCode,
+                'url' => $url,
+                'response' => substr($output, 0, 1000)
+            ]);
+            throw new \Exception("MediaWiki API request failed with HTTP code: $httpCode");
         }
 
         curl_close( $ch );
@@ -54,6 +67,11 @@ class MediawikiService {
         $result = json_decode( $output, true );
 
         if ($result === null) {
+            \Log::error('Failed to decode MediaWiki API response', [
+                'json_error' => json_last_error_msg(),
+                'url' => $url,
+                'response' => substr($output, 0, 1000)
+            ]);
             throw new \Exception('Failed to decode API response: ' . json_last_error_msg());
         }
 

--- a/app/Services/MediawikiService.php
+++ b/app/Services/MediawikiService.php
@@ -43,7 +43,9 @@ class MediawikiService {
         $output = curl_exec( $ch );
 
         if ($output === false) {
-            throw new \Exception('Failed to fetch data from the API: ' . curl_error($ch));
+            $errorMessage = curl_error($ch);
+            curl_close($ch);
+            throw new \Exception('Failed to fetch data from the API: ' . $errorMessage);
         }
 
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -67,7 +69,7 @@ class MediawikiService {
 
         $result = json_decode( $output, true );
 
-        if ($result === null) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             \Log::error('Failed to decode MediaWiki API response', [
                 'json_error' => json_last_error_msg(),
                 'url' => $url,

--- a/app/Services/MediawikiService.php
+++ b/app/Services/MediawikiService.php
@@ -39,6 +39,7 @@ class MediawikiService {
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
         curl_setopt( $ch, CURLOPT_TIMEOUT, 10 ); // Set timeout value in seconds
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10); // Set connect timeout value in seconds
+        curl_setopt($ch, CURLOPT_USERAGENT, "Wikipedia Golf Game/1.0 (https://github.com/oginoshikibu/wikipedia-golf)");
         $output = curl_exec( $ch );
 
         if ($output === false) {


### PR DESCRIPTION
## Summary
- Add HTTP status code validation before JSON decoding
- Add detailed error logging for failed API requests and JSON decode failures
- Add required User-Agent header for Wikipedia API compliance

## Problem Solved
- Prevents HTML error pages from causing JSON decode failures
- Fixes HTTP 403 errors due to missing User-Agent header (new Wikipedia requirement)
- Provides detailed logging for debugging future API issues

## Test plan
- [x] Verified API calls work with User-Agent header
- [x] Confirmed error logging captures response details
- [x] Tested HTTP status code validation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability and compliance of MediaWiki API requests.
> 
> - Sets `CURLOPT_USERAGENT` for Wikipedia API compliance
> - Validates HTTP status (`CURLINFO_HTTP_CODE`), handling timeouts (`0`) and non-`200` with detailed `\Log::error`
> - Enhances `curl_exec` failure handling by capturing error, closing handle, and throwing
> - Switches JSON validation to `json_last_error()` and logs decoding issues with request `url` and response snippet
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98fda0be21d564d405c05f56bc68556d7439eaa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->